### PR TITLE
Fix tests for 05 tables

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,16 @@ WriteMakefile(
                 dynamic_config => 0,
                 'meta-spec' => {version => 2},
                 no_index => {directory => [qw/t/]},
-                prereqs => {runtime => {requires => {perl => '5.008001'}}},
+                prereqs => {
+                    runtime => {
+                        requires => {
+                            perl => '5.008001'
+                        },
+                        recommends => {
+                            'Unicode::LineBreak' => 0,
+                        },
+                    }
+                },
                 resources => {
                     license => ['http://www.opensource.org/licenses/artistic-license-2.0'],
                     repository => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,8 @@ WriteMakefile(
                         },
                         recommends => {
                             'Unicode::LineBreak' => 0,
+                            'Text::VisualWidth::UTF8' => 0,
+                            'Text::VisualWidth::PP' => 0,
                         },
                     }
                 },

--- a/t/05tables_cjk.t
+++ b/t/05tables_cjk.t
@@ -6,7 +6,15 @@ use strict;
 use warnings;
 use utf8;
 
-use Test::More tests => 2;
+use Test::More;
+
+eval "use Unicode::GCString";
+if ($@) {
+    plan skip_all => "These tests require Unicode::GCString";
+}
+else {
+   plan tests => 2;
+}
 
 binmode STDERR, ":utf8";
 binmode STDOUT, ":utf8";


### PR DESCRIPTION
Hello,

This MR/PR will fix the following open bugs:
* https://rt.cpan.org/Public/Bug/Display.html?id=125547
* https://rt.cpan.org/Public/Bug/Display.html?id=125657

I've made three changes:
1) Skip t/05tables_cjk.t when Unicode::GCString is not installed
2) Add Unicode::GCString as a recommended runtime dependency
3) Add Text::VisualWidth::{UTF8,PP} also as recommended runtime dependencies
